### PR TITLE
fix(dump): Force ROM2 detection when ROM1 is available

### DIFF
--- a/biosdrain.c
+++ b/biosdrain.c
@@ -53,7 +53,6 @@ t_SysmanHardwareInfo g_hardwareInfo;
 void LoadSystemInformation()
 {
 	SysmanGetHardwareInfo(&g_hardwareInfo);
-
 	menu_status("BOOT ROM Info:\n");
 	menu_status("- ROM0 exists? %s\n", g_hardwareInfo.ROMs[0].IsExists ? "Yes" : "No");
 	if (g_hardwareInfo.ROMs[0].IsExists)

--- a/dump.c
+++ b/dump.c
@@ -62,7 +62,7 @@ void dump_init(u32 use_usb)
 		dump_jobs[1].dump_name = "ROM1";
 		dump_jobs[1].dump_fext = "rom1";
 		dump_jobs[1].dump_func = dump_rom1_func;
-		dump_jobs[1].dump_size = g_hardwareInfo.ROMs[1].size;
+		dump_jobs[1].dump_size = 0x80000;
 		dump_jobs[1].enabled = g_hardwareInfo.ROMs[1].IsExists;
 	}
 	// ROM2
@@ -70,8 +70,8 @@ void dump_init(u32 use_usb)
 		dump_jobs[2].dump_name = "ROM2";
 		dump_jobs[2].dump_fext = "rom2";
 		dump_jobs[2].dump_func = dump_rom2_func;
-		dump_jobs[2].dump_size = g_hardwareInfo.ROMs[2].size;
-		dump_jobs[2].enabled = g_hardwareInfo.ROMs[2].IsExists;
+		dump_jobs[2].dump_size = 0x80000;
+		dump_jobs[2].enabled = g_hardwareInfo.ROMs[1].IsExists;
 	}
 	// EROM
 	{
@@ -159,12 +159,12 @@ static u32 dump_rom0_func()
 }
 static u32 dump_rom1_func()
 {
-	common_dump_func(g_hardwareInfo.ROMs[1].StartAddress, g_hardwareInfo.ROMs[1].size);
+	common_dump_func(g_hardwareInfo.ROMs[1].StartAddress, 0x80000);
 	return 0;
 }
 static u32 dump_rom2_func()
 {
-	common_dump_func(g_hardwareInfo.ROMs[2].StartAddress, g_hardwareInfo.ROMs[2].size);
+	common_dump_func(g_hardwareInfo.ROMs[2].StartAddress, 0x80000);
 	return 0;
 }
 static u32 dump_erom_func()

--- a/sysman/rom.c
+++ b/sysman/rom.c
@@ -134,8 +134,9 @@ int ROMGetHardwareInfo(t_SysmanHardwareInfo *hwinfo)
 	}
 
 	// rom2 (part of DEV1)
+	// fobes: continuing this hack, but for ROM2
+	romAddDevice(2, (void*)0x1E400000);
 	pImgStat = romGetDevice(2);
-	printf("romGetDevice(%d) = %p\n", 2, pImgStat);
 	if (pImgStat != NULL)
 	{
 		hwinfo->ROMs[2].IsExists = 1;


### PR DESCRIPTION
ROM2 will either contain the character sets for consoles that need it, or will be ROM1, just mirrored.

Also set a fixed size for ROM1 and ROM2. As the size detection wasn't very reliable.