### PR TITLE
Dump ROM1 with EROM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.rom0
 *.rom1
 *.rom2
-*.erom
 *.mec
 *.nvm
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-EE_BIN ?= biosdrain.elf
+EE_BIN = biosdrain.elf
 EE_OBJS = biosdrain.o OSDInit.o sysman_rpc.o ui/menu.o dump.o modelname.o
 EE_OBJS += ui/fontqueue.o ui/tex/font/font_tex.o ui/tex/font/font_pallete_tex.o ui/fontengine.o
 EE_OBJS += ui/graphic.o ui/graphic_vu.o ui/tex/bongo_tex_1.o ui/tex/bongo_tex_2.o ui/tex/biosdrain_tex.o
@@ -57,7 +57,7 @@ ui/tex/font/font_pallete_tex.c: ui/tex/font/font_pallete_tex.raw
 
 clean:
 	$(MAKE) -C sysman clean
-	rm -f $(EE_BIN_RESET) $(EE_BIN_NORESET) $(EE_OBJS) $(IRX_C_FILES)
+	rm -f $(EE_OBJS) $(IRX_C_FILES)
 
 run: $(EE_BIN)
 	ps2client execee host:$(EE_BIN)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ If the path to your bios was `D:\ps2bios\dump` you'd see one of the below.
  - ROM0
  - ROM1*
  - ROM2*
- - EROM
  - NVM
  - MEC
 
@@ -52,7 +51,5 @@ If the path to your bios was `D:\ps2bios\dump` you'd see one of the below.
 ### Notes
 
 This software has been based off of the work from [PS2Ident](https://github.com/ps2homebrew/PS2Ident) licensed under AFL license-3.0 . The Sysman and Romdrv module source have been taken from there as well.
-
-Proper erom driver loading is not available on PCSX2. Thereby making erom dectection return a false negative. (Not that it really matters).
 
 Issues and pull requests are very much welcome. The issue tracker may be used by users to report successful dumping as well, as I only have a single 39K to test on. Please make sure your model doesn't already have a report though.

--- a/biosdrain.c
+++ b/biosdrain.c
@@ -40,18 +40,6 @@ void sysman_prerequesites()
 {
 	SifLoadModule("rom0:ADDDRV", 0, NULL);
 	SifLoadModule("rom0:ADDROM2", 0, NULL);
-
-	// Replace ? with a null terminator, required on some regions
-	char eromdrv[] = "rom1:EROMDRV?";
-	if (OSDGetDVDPlayerRegion(&eromdrv[12]) == 0 || eromdrv[12] != '\0')
-	{
-		eromdrv[12] = '\0'; // Replace '?' with a NULL.
-	}
-
-	// Finally, load the encrypted module
-	// Note, this doesn't work on pcsx2 and we will assume that there is no
-	// erom
-	SifLoadModuleEncrypted(eromdrv, 0, NULL);
 }
 
 t_SysmanHardwareInfo g_hardwareInfo;
@@ -66,7 +54,6 @@ void LoadSystemInformation()
 
 	menu_status("- DVD exists? %s\n", g_hardwareInfo.DVD_ROM.IsExists ? "Yes" : "No");
 	menu_status("- ROM1 exists? %s\n", g_hardwareInfo.ROMs[1].IsExists ? "Yes" : "No");
-	menu_status("- EROM exists? %s\n", g_hardwareInfo.erom.IsExists ? "Yes" : "No");
 	menu_status("- ROM2 exists? %s\n", g_hardwareInfo.ROMs[2].IsExists ? "Yes" : "No");
 
 	if (g_hardwareInfo.DVD_ROM.IsExists)
@@ -76,13 +63,6 @@ void LoadSystemInformation()
 	if (g_hardwareInfo.ROMs[1].IsExists)
 	{
 		menu_status(" - ROM1 ADDR and SIZE: %08X %08X\n", g_hardwareInfo.ROMs[1].StartAddress, g_hardwareInfo.ROMs[1].size);
-	}
-	if (g_hardwareInfo.erom.IsExists)
-	{
-		// Uses GetLoadcoreInternalData() to get the address of the encrypted module
-		// Turn 0xBE040000 -> 0x1E040000
-		g_hardwareInfo.erom.StartAddress &= ~(0xA << 0x1C);
-		menu_status(" - EROM ADDR and SIZE: %08X %08X\n", g_hardwareInfo.erom.StartAddress, g_hardwareInfo.erom.size);
 	}
 	if (g_hardwareInfo.ROMs[2].IsExists)
 	{

--- a/dump.c
+++ b/dump.c
@@ -14,7 +14,6 @@
 static u32 dump_rom0_func();
 static u32 dump_rom1_func();
 static u32 dump_rom2_func();
-static u32 dump_erom_func();
 static u32 dump_nvm_func();
 static u32 dump_mec_func();
 
@@ -63,7 +62,7 @@ void dump_init(u32 use_usb)
 		dump_jobs[1].dump_name = "ROM1";
 		dump_jobs[1].dump_fext = "rom1";
 		dump_jobs[1].dump_func = dump_rom1_func;
-		dump_jobs[1].dump_size = 0x80000;
+		dump_jobs[1].dump_size = 0x400000;
 		dump_jobs[1].enabled = g_hardwareInfo.ROMs[1].IsExists;
 	}
 	// ROM2
@@ -73,14 +72,6 @@ void dump_init(u32 use_usb)
 		dump_jobs[2].dump_func = dump_rom2_func;
 		dump_jobs[2].dump_size = 0x80000;
 		dump_jobs[2].enabled = g_hardwareInfo.ROMs[1].IsExists;
-	}
-	// EROM
-	{
-		dump_jobs[3].dump_name = "EROM";
-		dump_jobs[3].dump_fext = "erom";
-		dump_jobs[3].dump_func = dump_erom_func;
-		dump_jobs[3].dump_size = g_hardwareInfo.erom.size;
-		dump_jobs[3].enabled = g_hardwareInfo.erom.IsExists;
 	}
 	// NVM
 	{
@@ -131,7 +122,7 @@ void dump_cleanup()
 	free(dump_shared_buffer);
 }
 
-// Used for ROMx and EROM dumps
+// Used for ROMx dumps
 // Pretty much just a SysmanReadMemory wrapper
 static void common_dump_func(u32 start, u32 size)
 {
@@ -160,17 +151,12 @@ static u32 dump_rom0_func()
 }
 static u32 dump_rom1_func()
 {
-	common_dump_func(g_hardwareInfo.ROMs[1].StartAddress, 0x80000);
+	common_dump_func(g_hardwareInfo.ROMs[1].StartAddress, 0x400000);
 	return 0;
 }
 static u32 dump_rom2_func()
 {
 	common_dump_func(g_hardwareInfo.ROMs[2].StartAddress, 0x80000);
-	return 0;
-}
-static u32 dump_erom_func()
-{
-	common_dump_func(g_hardwareInfo.erom.StartAddress, g_hardwareInfo.erom.size);
 	return 0;
 }
 static u32 dump_nvm_func()


### PR DESCRIPTION
Fixes ROM1 dumps to 4MB. Verified that EROM is in the dumped ROM1.

Related: https://github.com/PCSX2/pcsx2/pull/6719