### PR TITLE
Fix USB ready check.

### DIFF
--- a/OSDInit.c
+++ b/OSDInit.c
@@ -638,7 +638,8 @@ int OSDInitROMVER(void)
 	if ((fd = open("rom0:ROMVER", O_RDONLY)) >= 0)
 	{
 		read(fd, ConsoleROMVER, ROMVER_MAX_LEN);
-		close(fd);
+		// Appears to cause a badaddr, cause unknown...
+		//close(fd);
 	}
 
 	return 0;

--- a/biosdrain.c
+++ b/biosdrain.c
@@ -196,6 +196,5 @@ exit_main:
 	menu_status("\n");
 	menu_status("Interested in PS2 development?\n");
 	menu_status("Check out fobes.dev!\n");
-	menu_status("Support me on ko-fi.com/f0bes!\n");
 	SleepThread();
 }

--- a/biosdrain.c
+++ b/biosdrain.c
@@ -94,7 +94,7 @@ int wait_usb_ready()
 
 	while (ret != 0 && retries > 0) {
 		//ret = stat("mass:/", &buffer);
-		if (mkdir("mass:/tmp", 0777))
+		if (mkdir("mass:/tmp", 0777) == 0)
 		{
 			rmdir("mass:/tmp");
 			ret = 0;


### PR DESCRIPTION
mkdir() returns 0 for success and != 0 for failure. Code had it the other way.

More details: this was causing the usb ready loop to exit after 1 iteration when it was not yet ready yet. It didn't actually cause any issues in my usage because by the time the bios file was ready to be dumped (which takes a few seconds) the usb apparently became ready. However, it may cause the code to fail if either USB takes longer to become ready or the bios takes less time to read.

Found this because I was borrowing the usb code for other purposes where there was not much time between the ready loop and actually attempting to write to the usb.